### PR TITLE
feat: add automatic backmerge configuration for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,8 @@ jobs:
             @semantic-release/changelog \
             @semantic-release/exec \
             semantic-release-replace-plugin \
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits \
+            @kilianpaquier/semantic-release-backmerge
 
       - name: Get build number
         id: build

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -105,3 +105,10 @@ plugins:
         - path: build/app/outputs/bundle/release/app-release.aab
           label: "App Bundle"
           name: "app-release-${nextRelease.version}.aab"
+
+  - - "@kilianpaquier/semantic-release-backmerge"
+    - commit: "chore(release): merge branch ${from} into ${to} [skip ci]"
+      targets:
+        - from: main
+          to: develop
+      title: "Automatic merge failure"


### PR DESCRIPTION
## Summary
- Added automatic backmerge functionality to keep main and develop branches in sync
- Configured semantic-release to automatically merge releases from main back to develop

## Changes
1. Added `@kilianpaquier/semantic-release-backmerge` plugin to `.releaserc.yml`
2. Configured backmerge to automatically merge from main to develop after releases
3. Updated GitHub Actions workflow to install the backmerge plugin

## Configuration Details
```yaml
- - "@kilianpaquier/semantic-release-backmerge"
  - commit: "chore(release): merge branch ${from} into ${to} [skip ci]"
    targets:
      - from: main
        to: develop
    title: "Automatic merge failure"
```

## Benefits
- Prevents divergence between main and develop branches
- Automatically keeps develop updated with latest releases
- Reduces manual merge work after releases
- Uses `[skip ci]` to prevent triggering additional workflows

## Test plan
- [ ] Verify the plugin is correctly installed in CI
- [ ] Test a release from main branch
- [ ] Confirm automatic merge PR is created to develop
- [ ] Verify merge commit includes `[skip ci]`

🤖 Generated with [Claude Code](https://claude.ai/code)